### PR TITLE
Auto-accept question in non-interactive shells

### DIFF
--- a/bdsx/installer/installer.ts
+++ b/bdsx/installer/installer.ts
@@ -25,6 +25,11 @@ function yesno(question:string, defaultValue?:boolean):Promise<boolean> {
     });
 
     return new Promise<boolean>(resolve=>{
+        if (!process.stdin.isTTY || process.env.BDSX_YES === "true") {
+            resolve(true);
+            return;
+        }
+
         rl.question(question + ' ', async(answer)=>{
             rl.close();
 


### PR DESCRIPTION
This is required for the Dockerfile to work as intended, especially when ran using docker-compose, where the shell is not interactive, so an answer to the yesno question cannot be read.

I also added a `BDSX_YES` env var that can be used when the installer is ran from scripts.